### PR TITLE
Ensure that both min and max are updated

### DIFF
--- a/src/f64_rect.rs
+++ b/src/f64_rect.rs
@@ -53,13 +53,15 @@ impl F64Rect {
     pub fn add_point(&mut self, point: &F64Point) {
         if self.min_x > point.x {
             self.min_x = point.x
-        } else if self.max_x < point.x {
+        }
+        if self.max_x < point.x {
             self.max_x = point.x
         }
 
         if self.min_y > point.y {
             self.min_y = point.y
-        } else if self.max_y < point.y {
+        }
+        if self.max_y < point.y {
             self.max_y = point.y
         }
     }


### PR DESCRIPTION
In the current implementation, there was a possibility that only min would be updated for rect coordinates and max would remain an incorrect `-f64::MAX`.
The above problem was solved by using `if` instead of `else if`.