### PR TITLE
Fix panic when constructing a PointAdapter with a degenerate rect

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -21,6 +21,16 @@ impl PointAdapter {
         let offset = F64Point { x: ox, y: oy };
 
         let max = a.max(b);
+
+        // degenerate case
+        if max == 0.0 {
+            return PointAdapter {
+                dir_scale: 1.0,
+                inv_scale: 1.0,
+                offset,
+            };
+        }
+
         let log2 = max.log2() as i32;
         let e = 29 - log2;
 


### PR DESCRIPTION
The following codes was panic when executed.
It is panic when the shape contains only one point or when it is degenerate to one point.

```rust
fn main() {
    let mut overlay = FloatOverlay::new();
    overlay.add_path(&[F64Point::new(10.0, 10.0)], ShapeType::Subject);
    let graph = overlay.build_graph(FillRule::NonZero);  // panic!
    let shapes = graph.extract_shapes(OverlayRule::Subject);
    println!("shapes: {:?}", shapes);
}
```

```rust
fn main() {
    let mut overlay = FloatOverlay::new();
    overlay.add_path(
        &[
            F64Point::new(10.0, 10.0),
            F64Point::new(10.0, 10.0),
            F64Point::new(10.0, 10.0),
            F64Point::new(10.0, 10.0),
        ],
        ShapeType::Subject,
    );
    overlay.add_path(
        &[
            F64Point::new(10.0, 10.0),
            F64Point::new(10.0, 10.0),
            F64Point::new(10.0, 10.0),
            F64Point::new(10.0, 10.0),
        ],
        ShapeType::Clip,
    );
    let graph = overlay.build_graph(FillRule::NonZero);  // panic!
    let shapes = graph.extract_shapes(OverlayRule::Subject);
    println!("shapes: {:?}", shapes);
}
```

If the shape of the overlay is degenerated to one point, the size of `union_rect` is 0x0 in `FloatOverlay::build_graph_with_solver()`, and the calculation of `log2` in `PointAdapter::new()` fails and overflows in the calculation of `e`. calculation fails and overflows in the calculation of `e`.

---

I fixed the panic by avoiding the overflow by giving special treatment to the case where the max value of the size of the rect passed to `PointAdapter::new` is 0.0.

Even if only `f64::EPSILON` is different as shown below, the above handling did not cause overflow.


```rust
fn main() {
    let mut overlay = FloatOverlay::new();
    overlay.add_path(
        &[F64Point::new(10.0, 0.0), F64Point::new(10.0, f64::EPSILON)],
        ShapeType::Subject,
    );
    let graph = overlay.build_graph(FillRule::NonZero);
    let shapes = graph.extract_shapes(OverlayRule::Subject);
    println!("shapes: {:?}", shapes);  // => "shapes: []"
}
```
